### PR TITLE
change spark master and workers to use python3.7.7 (used to be 2.7), …

### DIFF
--- a/Archive/py37env.Dockerfile
+++ b/Archive/py37env.Dockerfile
@@ -1,0 +1,46 @@
+# Choose your desired base image
+FROM jupyter/pyspark-notebook:1a66dd36ff82
+
+# built with the help of the below URL
+# https://jupyter-docker-stacks.readthedocs.io/en/latest/using/recipes.html#add-a-python-3-x-environment
+
+# name your environment and choose python 3.x version
+ARG conda_env=python37
+ARG py_ver=3.7.7
+
+
+#COPY --from=mambaorg/micromamba:0.17.0 "/home/${NB_USER}/mamba" "/home/${NB_USER}/mamba"
+#RUN wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba ./bin/micromamba shell init -s bash -p ~/micromamba
+#RUN source ~/.bashrc
+
+RUN conda --version
+#RUN conda config --set allow_conda_downgrades true
+#RUN conda install conda=4.6.141
+RUN conda install -c conda-forge mamba
+
+# you can add additional libraries you want mamba to install by listing them below the first line and ending with "&& \"
+RUN mamba create --quiet --yes -p "${CONDA_DIR}/envs/${conda_env}" python=${py_ver} ipython ipykernel && \
+    mamba clean --all -f -y
+
+# alternatively, you can comment out the lines above and uncomment those below
+# if you'd prefer to use a YAML file present in the docker build context
+
+# COPY --chown=${NB_UID}:${NB_GID} environment.yml "/home/${NB_USER}/tmp/"
+# RUN cd "/home/${NB_USER}/tmp/" && \
+#     mamba env create -p "${CONDA_DIR}/envs/${conda_env}" -f environment.yml && \
+#     mamba clean --all -f -y
+
+
+# create Python 3.x environment and link it to jupyter
+RUN "${CONDA_DIR}/envs/${conda_env}/bin/python" -m ipykernel install --user --name="${conda_env}" && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+# any additional pip installs can be added by uncommenting the following line
+# RUN "${CONDA_DIR}/envs/${conda_env}/bin/pip" install
+
+# prepend conda environment to path
+ENV PATH "${CONDA_DIR}/envs/${conda_env}/bin:${PATH}"
+
+# if you want this environment to be the default one, uncomment the following line:
+# ENV CONDA_DEFAULT_ENV ${conda_env}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,13 @@ volumes:
 
 services:
   jupyterlab:
-    image: jupyter/pyspark-notebook:1a66dd36ff82
+    image: trentsteel777/pyspark-notebook-py377:latest
     container_name: jupyterlab
     environment:
       - JUPYTER_ENABLE_LAB=yes
+      - PYSPARK_DRIVER_PYTHON=python3
+      - PYSPARK_PYTHON=python3
+      - PYTHON_VERSION=3.7
     ports:
       - 8888:8888
     volumes:
@@ -26,6 +29,9 @@ services:
   spark-master:
     image: bde2020/spark-master:3.0.0-hadoop3.2
     container_name: spark-master
+    environment:
+      - PYSPARK_PYTHON=/usr/bin/python3
+      - PYSPARK_DRIVER_PYTHON=/usr/bin/python3
     ports:
       - 8080:8080
       - 7077:7077
@@ -39,7 +45,9 @@ services:
     container_name: spark-worker-1
     environment:
       - SPARK_WORKER_CORES=4
-      - SPARK_WORKER_MEMORY=4g
+      - SPARK_WORKER_MEMORY=5g
+      - PYSPARK_PYTHON=/usr/bin/python3
+      - PYSPARK_DRIVER_PYTHON=/usr/bin/python3
     ports:
       - 8081:8081
     volumes:
@@ -53,7 +61,9 @@ services:
     container_name: spark-worker-2
     environment:
       - SPARK_WORKER_CORES=4
-      - SPARK_WORKER_MEMORY=4g
+      - SPARK_WORKER_MEMORY=5g
+      - PYSPARK_PYTHON=/usr/bin/python3
+      - PYSPARK_DRIVER_PYTHON=/usr/bin/python3
     ports:
       - 8082:8081
     volumes:

--- a/readme2.txt
+++ b/readme2.txt
@@ -9,3 +9,15 @@ Helpful commands:
   docker rm -f $(docker ps -a -q)
   docker exec -it jupyterlab /opt/conda/bin/jupyter notebook list
   docker logs --tail 100 --follow --timestamps jupyterlab
+
+
+
+    #1a66dd36ff82 3.8.4
+    #7d0e50e30763 3.8.5
+    #229c7fea9d60 
+    #5197709e9f23 
+    #04f7f60d34a6 3.7.6
+    #c094bb7219f9 
+    #b90cce83f37b 
+    #54462805efcb
+    #image: jupyter/pyspark-notebook:1a66dd36ff82


### PR DESCRIPTION
…Add conda environement for jupyterlab image to include python3.7.7, out of the box it was 3.8.4 which doesnt work with pyspark udfs because there was a version mismatch with spark containers. I did this by building my own image to include a python3.7.7 environment inside the jupyterlab docker image from jupyter/pyspark-notebook:1a66dd36ff82, see: Archive/py37env.Dockerfile. This image is on dockerhub as trentsteel777/pyspark-notebook-py377:latest